### PR TITLE
Not to Lookup URLs as Words

### DIFF
--- a/include/lookup.js
+++ b/include/lookup.js
@@ -10,6 +10,9 @@ function valid_word(word) {
     if (word.length === 0 || word.length > 190) {
         return false;
     }
+    if (word.startsWith("https://") || word.startsWith("http://")) {
+        return false;
+    }
     if (is_chinese(word)) {
         return "Chinese";
     }


### PR DESCRIPTION
Hi, recently I discovered a bug(well, I think so...) where HaloWord tries to do lookups when I Ctrl+Mouse Left on a url (in order to open it in a new tab). This is annoying when e.g. I'm trying to open multiple search results from Google at once... So in the PR I modified the extension not to see common URLS(starts with `http://` or `https://`) as words. This should be a fix in most of the time.